### PR TITLE
Cargo config (target dir) fix and improvement

### DIFF
--- a/rusty_roguelike-bevy/.cargo/config.toml
+++ b/rusty_roguelike-bevy/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "./target"

--- a/source_projects/rusty_roguelike/.cargo/config.toml
+++ b/source_projects/rusty_roguelike/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "./target"


### PR DESCRIPTION
- Rusty Roguelike: Restore and improve cargo target configuration
- Add (.cargo) shared target dir also to Rusty Roguelike source project