### PR TITLE
Fix three Rusty Roguelike bugs

### DIFF
--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/player_input.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
 pub fn player_input(
+    mut commands: Commands,
     mut query: Query<(&Player, &mut PointC)>, //(1) (2)
     (map, key, mut camera, mut turn_state): (
         Res<Map>,
@@ -31,5 +32,13 @@ pub fn player_input(
                 }
             }
         }
+
+        // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
+        // the same frame. This is because a system (set) may run multiple times over a frame, due to
+        // state circularity.
+        // By removing they key, once this system is run a second time, no keypress is detected, and
+        // the circle stops.
+        //
+        commands.remove_resource::<VirtualKeyCode>();
     }
 }

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 pub fn player_input(
     mut commands: Commands,
     mut move_events: EventWriter<WantsToMove>,
-    mut query: Query<(Entity, &PointC)>, //(1) (2)
+    mut query: Query<(Entity, &PointC), With<Player>>, //(1) (2)
     (key, mut turn_state): (Option<Res<VirtualKeyCode>>, ResMut<State<TurnState>>),
 ) {
     use TurnState::PlayerTurn;

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
 pub fn player_input(
+    mut commands: Commands,
     mut move_events: EventWriter<WantsToMove>,
     mut query: Query<(Entity, &PointC)>, //(1) (2)
     (key, mut turn_state): (Option<Res<VirtualKeyCode>>, ResMut<State<TurnState>>),
@@ -27,5 +28,13 @@ pub fn player_input(
             }
         }
         turn_state.set(PlayerTurn).unwrap();
+
+        // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
+        // the same frame. This is because a system (set) may run multiple times over a frame, due to
+        // state circularity.
+        // By removing they key, once this system is run a second time, no keypress is detected, and
+        // the circle stops.
+        //
+        commands.remove_resource::<VirtualKeyCode>();
     }
 }


### PR DESCRIPTION
- Fix system sets ordering
- Fix player_input system running multiple times over a frame
- Fix player_input system not filtering out enemies

There are still two problems:

1. sprites have visible ghosting
2. the port can runs only one state per update; Bevy runs all the system sets

It's not clear if they're all related.