### PR TITLE
Remove clippy::pedantic derive

### DIFF
--- a/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
+++ b/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
+++ b/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod game_step;

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod events;

--- a/source_projects/rusty_roguelike/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
+++ b/source_projects/rusty_roguelike/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
+++ b/source_projects/rusty_roguelike/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/07_TurnBasedGames_01_wandering/src/main.rs
+++ b/source_projects/rusty_roguelike/07_TurnBasedGames_01_wandering/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/07_TurnBasedGames_02_turnbased/src/main.rs
+++ b/source_projects/rusty_roguelike/07_TurnBasedGames_02_turnbased/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/07_TurnBasedGames_03_intent/src/main.rs
+++ b/source_projects/rusty_roguelike/07_TurnBasedGames_03_intent/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/08_HealthSimpleMelee_01_health/src/main.rs
+++ b/source_projects/rusty_roguelike/08_HealthSimpleMelee_01_health/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/08_HealthSimpleMelee_02_combat/src/main.rs
+++ b/source_projects/rusty_roguelike/08_HealthSimpleMelee_02_combat/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/08_HealthSimpleMelee_03_healing/src/main.rs
+++ b/source_projects/rusty_roguelike/08_HealthSimpleMelee_03_healing/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/09_WinningAndLosing_01_gauntlet/src/main.rs
+++ b/source_projects/rusty_roguelike/09_WinningAndLosing_01_gauntlet/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/09_WinningAndLosing_02_losing/src/main.rs
+++ b/source_projects/rusty_roguelike/09_WinningAndLosing_02_losing/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/09_WinningAndLosing_03_winning/src/main.rs
+++ b/source_projects/rusty_roguelike/09_WinningAndLosing_03_winning/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/10_WhatCanISee_01_fov/src/main.rs
+++ b/source_projects/rusty_roguelike/10_WhatCanISee_01_fov/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/10_WhatCanISee_02_eyesight/src/main.rs
+++ b/source_projects/rusty_roguelike/10_WhatCanISee_02_eyesight/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/10_WhatCanISee_03_memory/src/main.rs
+++ b/source_projects/rusty_roguelike/10_WhatCanISee_03_memory/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/11_MoreInterestingDungeons_02_traits_rooms/src/main.rs
+++ b/source_projects/rusty_roguelike/11_MoreInterestingDungeons_02_traits_rooms/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/11_MoreInterestingDungeons_06_prefab/src/main.rs
+++ b/source_projects/rusty_roguelike/11_MoreInterestingDungeons_06_prefab/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/12_MapTheming_01_themed/src/main.rs
+++ b/source_projects/rusty_roguelike/12_MapTheming_01_themed/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/13_InventoryAndPowerUps_01_potions_and_scrolls/src/main.rs
+++ b/source_projects/rusty_roguelike/13_InventoryAndPowerUps_01_potions_and_scrolls/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/13_InventoryAndPowerUps_02_carrying_items/src/main.rs
+++ b/source_projects/rusty_roguelike/13_InventoryAndPowerUps_02_carrying_items/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/14_DeeperDungeons_more_levels/src/main.rs
+++ b/source_projects/rusty_roguelike/14_DeeperDungeons_more_levels/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/15_Loot_01_loot_tables/src/main.rs
+++ b/source_projects/rusty_roguelike/15_Loot_01_loot_tables/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;

--- a/source_projects/rusty_roguelike/15_Loot_02_better_combat/src/main.rs
+++ b/source_projects/rusty_roguelike/15_Loot_02_better_combat/src/main.rs
@@ -1,5 +1,3 @@
-#![warn(clippy::pedantic)]
-
 mod camera;
 mod components;
 mod map;


### PR DESCRIPTION
It doesn't make much sense - the source project was no clean to start with, so it just adds warnings on top of the existing ones.