### PR TITLE
Rusty Roguelike: Remove ecs.runner extraction

### DIFF
--- a/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
+++ b/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_01_playerecs/src/main.rs
@@ -40,9 +40,8 @@ impl State {
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         ecs.add_system_set(build_system_set());
-        // The following two statements simulate Bevy's App#run(), giving us ownership of App.
+        // This is the way used by App#run to get ownership of the App instance.
         ecs = std::mem::replace(&mut ecs, App::empty());
-        ecs.runner = Box::new(|_| {});
         Self { ecs }
     }
 }

--- a/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
+++ b/rusty_roguelike-bevy/06_EntitiesComponentsAndSystems_02_dungeonecs/src/main.rs
@@ -46,9 +46,8 @@ impl State {
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         ecs.add_system_set(build_system_set());
-        // The following two statements simulate Bevy's App#run(), giving us ownership of App.
+        // This is the way used by App#run to get ownership of the App instance.
         ecs = std::mem::replace(&mut ecs, App::empty());
-        ecs.runner = Box::new(|_| {});
         Self { ecs }
     }
 }

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
@@ -59,9 +59,8 @@ impl State {
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
-        // The following two statements simulate Bevy's App#run(), giving us ownership of App.
+        // This is the way used by App#run to get ownership of the App instance.
         ecs = std::mem::replace(&mut ecs, App::empty());
-        ecs.runner = Box::new(|_| {});
         Self { ecs }
     }
 }

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
@@ -63,9 +63,8 @@ impl State {
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
-        // The following two statements simulate Bevy's App#run(), giving us ownership of App.
+        // This is the way used by App#run to get ownership of the App instance.
         ecs = std::mem::replace(&mut ecs, App::empty());
-        ecs.runner = Box::new(|_| {});
         Self { ecs }
     }
 }


### PR DESCRIPTION
Irrelevant in the context of our custom game loop.