### PR TITLE
Fyrox-soccer: Use Pivot as root node

### DIFF
--- a/soccer-fyrox/Cargo.toml
+++ b/soccer-fyrox/Cargo.toml
@@ -6,4 +6,3 @@ version = "0.1.0"
 [dependencies]
 
 fyrox = "0.25.0"
-imagesize = "0.9"

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -38,44 +38,13 @@ pub struct GameGlobal {
     menu_difficulty: u8,
 }
 
-fn preset_window(engine: &Engine) {
-    let window = engine.get_window();
-
-    window.set_inner_size(PhysicalSize {
-        width: WIDTH,
-        height: HEIGHT,
-    });
-
-    window.set_resizable(false);
-}
-
-// Returns (scene, camera, (phony) backgroud node)
-//
-fn build_initial_scene(engine: &mut Engine) -> (Handle<Scene>, Handle<Node>, Handle<Node>) {
-    let mut scene = Scene::new();
-
-    let camera = CameraBuilder::new(BaseBuilder::new())
-        .with_projection(Projection::Orthographic(OrthographicProjection {
-            z_near: -0.1,
-            z_far: 16.0,
-            vertical_size: HEIGHT / 2.0,
-        }))
-        .build(&mut scene.graph);
-
-    let background_node = RectangleBuilder::new(BaseBuilder::new()).build(&mut scene.graph);
-
-    let scene = engine.scenes.add(scene);
-
-    (scene, camera, background_node)
-}
-
 impl GameState for GameGlobal {
     fn init(engine: &mut Engine) -> Self {
-        preset_window(engine);
+        Self::preset_window(engine);
 
         let resources = Resources::load(&engine.resource_manager);
 
-        let (scene, camera, background) = build_initial_scene(engine);
+        let (scene, camera, background) = Self::build_initial_scene(engine);
 
         let input = InputController::new();
 
@@ -131,6 +100,17 @@ impl GameState for GameGlobal {
 // the source code simpler.
 //
 impl GameGlobal {
+    fn preset_window(engine: &Engine) {
+        let window = engine.get_window();
+
+        window.set_inner_size(PhysicalSize {
+            width: WIDTH,
+            height: HEIGHT,
+        });
+
+        window.set_resizable(false);
+    }
+
     fn update(&mut self, _engine: &mut Engine) {
         use VirtualKeyCode::*;
         use {MenuState::*, State::*};
@@ -224,5 +204,25 @@ impl GameGlobal {
                 //
             }
         }
+    }
+
+    // Returns (scene, camera, (phony) backgroud node)
+    //
+    fn build_initial_scene(engine: &mut Engine) -> (Handle<Scene>, Handle<Node>, Handle<Node>) {
+        let mut scene = Scene::new();
+
+        let camera = CameraBuilder::new(BaseBuilder::new())
+            .with_projection(Projection::Orthographic(OrthographicProjection {
+                z_near: -0.1,
+                z_far: 16.0,
+                vertical_size: HEIGHT / 2.0,
+            }))
+            .build(&mut scene.graph);
+
+        let background_node = RectangleBuilder::new(BaseBuilder::new()).build(&mut scene.graph);
+
+        let scene = engine.scenes.add(scene);
+
+        (scene, camera, background_node)
     }
 }

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -195,8 +195,8 @@ impl GameGlobal {
                     Difficulty => (1, self.menu_difficulty),
                 };
 
-                let image_data = self.resources.image("menu", &[image_i1, image_i2]);
-                let background = build_image_node(&mut scene.graph, image_data, 0, 0, 0);
+                let texture = self.resources.image("menu", &[image_i1, image_i2]);
+                let background = build_image_node(&mut scene.graph, texture, 0, 0, 0);
                 scene.graph.link_nodes(background, self.root_node);
             }
             Play => {

--- a/soccer-fyrox/src/resources.rs
+++ b/soccer-fyrox/src/resources.rs
@@ -4,7 +4,6 @@ use fyrox::{
     core::futures::executor::block_on, engine::resource_manager::ResourceManager,
     resource::texture::Texture,
 };
-use imagesize::ImageSize;
 
 const ZERO_ORD: u8 = '0' as u8;
 
@@ -17,7 +16,7 @@ const IMAGE_PATHS: &'static [&'static str] = &[
 ];
 
 pub struct Resources {
-    images: HashMap<String, (Texture, f32, f32)>,
+    images: HashMap<String, Texture>,
 }
 
 impl Resources {
@@ -36,15 +35,14 @@ impl Resources {
 
         for (path, texture_request) in texture_requests {
             let texture = block_on(texture_request).unwrap();
-            let ImageSize { width, height } = imagesize::size(path).unwrap();
 
-            images.insert(path.to_string(), (texture, width as f32, height as f32));
+            images.insert(path.to_string(), texture);
         }
 
         Self { images }
     }
 
-    pub fn image(&self, base: &str, indexes: &[u8]) -> (Texture, f32, f32) {
+    pub fn image(&self, base: &str, indexes: &[u8]) -> Texture {
         if indexes.len() > 2 {
             panic!();
         }

--- a/soccer-fyrox/src/texture_node_builder.rs
+++ b/soccer-fyrox/src/texture_node_builder.rs
@@ -20,12 +20,11 @@ pub fn build_image_node(
     y: i16,
     z: i16,
 ) -> Handle<Node> {
-    let (texture, width, height) = image_data;
+    let (texture, _width, _height) = image_data;
 
     RectangleBuilder::new(
         BaseBuilder::new().with_local_transform(
             TransformBuilder::new()
-                .with_local_scale(Vector3::new(width, height, f32::EPSILON))
                 .with_local_position(Vector3::new(x as f32, y as f32, z as f32))
                 .build(),
         ),

--- a/soccer-fyrox/src/texture_node_builder.rs
+++ b/soccer-fyrox/src/texture_node_builder.rs
@@ -15,13 +15,11 @@ use fyrox::{
 //
 pub fn build_image_node(
     graph: &mut Graph,
-    image_data: (Texture, f32, f32),
+    texture: Texture,
     x: i16,
     y: i16,
     z: i16,
 ) -> Handle<Node> {
-    let (texture, _width, _height) = image_data;
-
     RectangleBuilder::new(
         BaseBuilder::new().with_local_transform(
             TransformBuilder::new()


### PR DESCRIPTION
Very convenient (in addition to be more idiomatic); possibly, also necessary, depending on other states using partial backgrounds rather than a single one.