### PR TITLE
Soccer-fyrox: Generalize looping sounds support, and follow up with port

### DIFF
--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -76,23 +76,23 @@ DEBUG_SHOW_PEERS = False
 DEBUG_SHOW_SHOOT_TARGET = False
 DEBUG_SHOW_COSTS = False
 
-class Difficulty:
-    def __init__(self, goalie_enabled, second_lead_enabled, speed_boost, holdoff_timer):
-        self.goalie_enabled = goalie_enabled
-
-        # When a player has the ball, either one or two players will be chosen from the other team to try to intercept
-        # the ball owner. Those players will have their 'lead' attributes set to a number indicating how far ahead of the
-        # ball they should try to run. (If they tried to go to where the ball is currently, they'd always trail behind)
-        # This attribute determines whether there should be one or two lead players
-        self.second_lead_enabled = second_lead_enabled
-
-        # Speed boost to apply to CPU-team players in certain circumstances
-        self.speed_boost = speed_boost
-
-        # Hold-off timer limits rate at which computer-controlled players can pass the ball
-        self.holdoff_timer = holdoff_timer
-
-DIFFICULTY = [Difficulty(False, False, 0, 120), Difficulty(False, True, 0.1, 90), Difficulty(True, True, 0.2, 60)]
+# class Difficulty:
+#     def __init__(self, goalie_enabled, second_lead_enabled, speed_boost, holdoff_timer):
+#         self.goalie_enabled = goalie_enabled
+#
+#         # When a player has the ball, either one or two players will be chosen from the other team to try to intercept
+#         # the ball owner. Those players will have their 'lead' attributes set to a number indicating how far ahead of the
+#         # ball they should try to run. (If they tried to go to where the ball is currently, they'd always trail behind)
+#         # This attribute determines whether there should be one or two lead players
+#         self.second_lead_enabled = second_lead_enabled
+#
+#         # Speed boost to apply to CPU-team players in certain circumstances
+#         self.speed_boost = speed_boost
+#
+#         # Hold-off timer limits rate at which computer-controlled players can pass the ball
+#         self.holdoff_timer = holdoff_timer
+#
+# DIFFICULTY = [Difficulty(False, False, 0, 120), Difficulty(False, True, 0.1, 90), Difficulty(True, True, 0.2, 60)]
 
 # Custom sine/cosine functions for angles of 0 to 7, where 0 is up,
 # 1 is up+right, 2 is right, etc.
@@ -695,8 +695,8 @@ class Team:
 
 class Game:
     def __init__(self, p1_controls=None, p2_controls=None, difficulty=2):
-        self.teams = [Team(p1_controls), Team(p2_controls)]
-        self.difficulty = DIFFICULTY[difficulty]
+#         self.teams = [Team(p1_controls), Team(p2_controls)]
+#         self.difficulty = DIFFICULTY[difficulty]
 
         try:
             if self.teams[0].human():

--- a/soccer-fyrox/src/difficulty.rs
+++ b/soccer-fyrox/src/difficulty.rs
@@ -1,0 +1,35 @@
+pub const DIFFICULTY: [Difficulty; 3] = [
+    Difficulty::new(false, false, 0.0, 120),
+    Difficulty::new(false, true, 0.1, 90),
+    Difficulty::new(true, true, 0.2, 60),
+];
+
+#[derive(Clone, Copy)]
+pub struct Difficulty {
+    goalie_enabled: bool,
+    // When a player has the ball, either one or two players will be chosen from the other team to try to intercept
+    // the ball owner. Those players will have their 'lead' attributes set to a number indicating how far ahead of the
+    // ball they should try to run. (If they tried to go to where the ball is currently, they'd always trail behind)
+    // This attribute determines whether there should be one or two lead players
+    second_lead_enabled: bool,
+    // Speed boost to apply to CPU-team players in certain circumstances
+    speed_boost: f32,
+    // Hold-off timer limits rate at which computer-controlled players can pass the ball
+    holdoff_timer: u32,
+}
+
+impl Difficulty {
+    pub const fn new(
+        goalie_enabled: bool,
+        second_lead_enabled: bool,
+        speed_boost: f32,
+        holdoff_timer: u32,
+    ) -> Self {
+        Self {
+            goalie_enabled,
+            second_lead_enabled,
+            speed_boost,
+            holdoff_timer,
+        }
+    }
+}

--- a/soccer-fyrox/src/game.rs
+++ b/soccer-fyrox/src/game.rs
@@ -1,10 +1,14 @@
-use crate::{controls::Controls, team::Team};
+use crate::{
+    controls::Controls,
+    difficulty::{self, Difficulty},
+    team::Team,
+};
 
 pub const DEFAULT_DIFFICULTY: u8 = 2;
 
 pub struct Game {
     pub teams: Vec<Team>,
-    difficulty: u8,
+    difficulty: Difficulty,
     pub score_timer: i32,
 }
 
@@ -16,6 +20,7 @@ impl Game {
     ) -> Self {
         let teams = vec![Team::new(p1_controls), Team::new(p2_controls)];
         let score_timer = 0;
+        let difficulty = difficulty::DIFFICULTY[difficulty as usize];
 
         Self {
             teams,

--- a/soccer-fyrox/src/game.rs
+++ b/soccer-fyrox/src/game.rs
@@ -1,6 +1,9 @@
+use fyrox::scene::Scene;
+
 use crate::{
     controls::Controls,
     difficulty::{self, Difficulty},
+    media::Media,
     team::Team,
 };
 
@@ -17,10 +20,24 @@ impl Game {
         p1_controls: Option<Controls>,
         p2_controls: Option<Controls>,
         difficulty: u8,
+        scene: &mut Scene,
+        media: &mut Media,
     ) -> Self {
         let teams = vec![Team::new(p1_controls), Team::new(p2_controls)];
         let score_timer = 0;
         let difficulty = difficulty::DIFFICULTY[difficulty as usize];
+
+        if teams[0].human() {
+            // Beginning a game with at least 1 human player
+            // music.fadeout(1); // WRITEME: Fyrox doesn't currently support fading out
+            media.stop_looping_sound(scene, "music/theme"); // ^^ remove once fadeout is implemented
+            media.play_looping_sound(scene, "sounds/crowd");
+            media.play_sound(scene, "start", &[]);
+        } else {
+            // No players - we must be on the menu. Play title music.
+            media.play_looping_sound(scene, "music/theme");
+            media.stop_looping_sound(scene, "sounds/crowd");
+        }
 
         Self {
             teams,

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -145,7 +145,7 @@ impl GameGlobal {
                         selection_change = -1;
                     }
                     if selection_change != 0 {
-                        self.media.play_sound(&mut scene, "move", &[]);
+                        self.media.play_sound(&mut scene, "sounds/move", &[]);
                         if let Some(MenuState::NumPlayers) = self.menu_state {
                             self.menu_num_players = if self.menu_num_players == 1 { 2 } else { 1 };
                         } else {

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -43,11 +43,11 @@ impl GameState for GameGlobal {
 
         let camera = Self::build_camera(&mut scene);
 
-        let media = Media::new(&engine.resource_manager, &mut scene);
+        let mut media = Media::new(&engine.resource_manager, &mut scene);
 
         let input = InputController::new();
 
-        let game = Game::new(None, None, game::DEFAULT_DIFFICULTY);
+        let game = Game::new(None, None, game::DEFAULT_DIFFICULTY, &mut scene, &mut media);
         let state = State::Menu;
         let menu_state = Some(MenuState::NumPlayers);
 
@@ -128,13 +128,21 @@ impl GameGlobal {
                                 Some(Controls::new(0)),
                                 Some(Controls::new(1)),
                                 game::DEFAULT_DIFFICULTY,
+                                &mut scene,
+                                &mut self.media,
                             )
                         }
                     } else {
                         // Start 1P game
                         self.state = State::Play;
                         self.menu_state = None;
-                        self.game = Game::new(Some(Controls::new(0)), None, self.menu_difficulty);
+                        self.game = Game::new(
+                            Some(Controls::new(0)),
+                            None,
+                            self.menu_difficulty,
+                            &mut scene,
+                            &mut self.media,
+                        );
                     }
                 } else {
                     // Detect + act on up/down arrow keys
@@ -172,7 +180,13 @@ impl GameGlobal {
                     // Switch to menu state, and create a new game object without a player
                     self.state = State::Menu;
                     self.menu_state = Some(MenuState::NumPlayers);
-                    self.game = Game::new(None, None, game::DEFAULT_DIFFICULTY);
+                    self.game = Game::new(
+                        None,
+                        None,
+                        game::DEFAULT_DIFFICULTY,
+                        &mut scene,
+                        &mut self.media,
+                    );
                 }
             }
         }

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -24,7 +24,7 @@ pub const WIDTH: f32 = 800.0;
 pub const HEIGHT: f32 = 480.0;
 
 pub struct GameGlobal {
-    resources: Media,
+    media: Media,
     scene: Handle<Scene>,
     camera: Handle<Node>,
     input: InputController,
@@ -43,7 +43,7 @@ impl GameState for GameGlobal {
 
         let camera = Self::build_camera(&mut scene);
 
-        let resources = Media::new(&engine.resource_manager, &mut scene);
+        let media = Media::new(&engine.resource_manager, &mut scene);
 
         let input = InputController::new();
 
@@ -54,7 +54,7 @@ impl GameState for GameGlobal {
         let scene_h = engine.scenes.add(scene);
 
         Self {
-            resources,
+            media,
             scene: scene_h,
             camera,
             input,
@@ -69,7 +69,7 @@ impl GameState for GameGlobal {
     fn on_tick(&mut self, engine: &mut Engine, _dt: f32, _control_flow: &mut ControlFlow) {
         let mut scene = &mut engine.scenes[self.scene];
 
-        self.resources.clear_images(&mut scene);
+        self.media.clear_images(&mut scene);
 
         self.update(engine);
 
@@ -145,7 +145,7 @@ impl GameGlobal {
                         selection_change = -1;
                     }
                     if selection_change != 0 {
-                        self.resources.play_sound(&mut scene, "move", &[]);
+                        self.media.play_sound(&mut scene, "move", &[]);
                         if let Some(MenuState::NumPlayers) = self.menu_state {
                             self.menu_num_players = if self.menu_num_players == 1 { 2 } else { 1 };
                         } else {
@@ -192,7 +192,7 @@ impl GameGlobal {
                     Difficulty => (1, self.menu_difficulty),
                 };
 
-                self.resources
+                self.media
                     .draw_image(scene, "menu", &[image_i1, image_i2], 0, 0, 0);
             }
             Play => {

--- a/soccer-fyrox/src/main.rs
+++ b/soccer-fyrox/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 mod controls;
+mod difficulty;
 mod game;
 mod game_global;
 mod input_controller;

--- a/soccer-fyrox/src/media.rs
+++ b/soccer-fyrox/src/media.rs
@@ -42,7 +42,7 @@ pub struct Media {
     image_textures: HashMap<String, Texture>,
     sound_resources: HashMap<String, SoundBufferResource>,
     images_root: Handle<Node>,
-    music: Option<Handle<Node>>,
+    looping_sounds: HashMap<String, Handle<Node>>,
 }
 
 impl Media {
@@ -87,13 +87,13 @@ impl Media {
         )
         .build(&mut scene.graph);
 
-        let music = None;
+        let looping_sounds = HashMap::new();
 
         Self {
             image_textures,
             sound_resources,
             images_root,
-            music,
+            looping_sounds,
         }
     }
 
@@ -125,8 +125,7 @@ impl Media {
     }
 
     pub fn play_sound(&self, scene: &mut Scene, base: &str, indexes: &[u8]) {
-        let base = "sounds/".to_string() + base;
-        let sound = self.sound(base, indexes);
+        let sound = self.sound(&base, indexes);
 
         SoundBuilder::new(BaseBuilder::new())
             .with_buffer(Some(sound))
@@ -135,30 +134,38 @@ impl Media {
             .build(&mut scene.graph);
     }
 
-    pub fn play_music(&mut self, scene: &mut Scene, base: &str) {
-        if self.music.is_some() {
-            panic!("There must be no music references, in order to play_music()");
-        }
+    // In PyGame, music is a streamed (and repeated) sound; in Fyrox, there isn't the streaming concept.
+    // In the source project, looping sounds don't have an index.
+    //
+    // We could merge this and the play_sound(), but it's simpler (API-wise) to separate them, taking
+    // advantage of the two points above.
+    //
+    pub fn play_looping_sound(&mut self, scene: &mut Scene, name: &str) {
+        let sound = self.sound(name, &[]);
 
-        let base = "music/".to_string() + base;
-        let sound = self.sound(base, &[]);
+        let node = SoundBuilder::new(BaseBuilder::new())
+            .with_buffer(Some(sound))
+            .with_looping(true)
+            .with_status(Status::Playing)
+            .build(&mut scene.graph);
 
-        self.music = Some(
-            SoundBuilder::new(BaseBuilder::new())
-                .with_buffer(Some(sound))
-                .with_looping(true)
-                .with_status(Status::Playing)
-                .build(&mut scene.graph),
-        );
+        self.looping_sounds.insert(name.to_string(), node);
     }
 
-    fn stop_music(&mut self, scene: &mut Scene) {
-        let music_h = self
-            .music
-            .expect("A music reference must exist, in order to stop_music()!");
+    // The source project allows attempting to stop a sound that hasn't been started.
+    //
+    // Looping sounds don't have an index (see play_sound()).
+    //
+    pub fn stop_looping_sound(&mut self, scene: &mut Scene, base: &str) {
+        if let Some(sound_h) = self.looping_sounds.remove(base) {
+            let sound = &mut scene.graph[sound_h];
 
-        scene.remove_node(music_h);
-        self.music = None;
+            // Removing the node also stops the sound, so this is technically redundant.
+            //
+            sound.as_sound_mut().stop();
+
+            scene.remove_node(sound_h);
+        }
     }
 
     fn image<S: AsRef<str> + Display>(&self, base: S, indexes: &[u8]) -> Texture {

--- a/soccer-fyrox/src/media.rs
+++ b/soccer-fyrox/src/media.rs
@@ -32,8 +32,11 @@ const IMAGE_PATHS: &'static [&'static str] = &[
     "resources/images/menu12.png",
 ];
 
-const SOUND_PATHS: &'static [&'static str] =
-    &["resources/sounds/move.ogg", "resources/music/theme.ogg"];
+const SOUND_PATHS: &'static [&'static str] = &[
+    "resources/sounds/move.ogg",
+    "resources/sounds/start.ogg",
+    "resources/music/theme.ogg",
+];
 
 // It's not easy to make the overall design of the program simple, since Fyrox requires several elements
 // to be carried around (scene, handles, resources...).

--- a/soccer-fyrox/src/team.rs
+++ b/soccer-fyrox/src/team.rs
@@ -11,4 +11,8 @@ impl Team {
 
         Self { controls, score }
     }
+
+    pub fn human(&self) -> bool {
+        self.controls.is_some()
+    }
 }


### PR DESCRIPTION
Now there is a general concept of looping sound, instead of a single music instance (this was required).

Some small follow ups with the port.