### PR TITLE
Soccer-fyrox: Remove window resizing workaround (and update winit dependency)

### DIFF
--- a/soccer-fyrox/Cargo.toml
+++ b/soccer-fyrox/Cargo.toml
@@ -6,3 +6,8 @@ version = "0.1.0"
 [dependencies]
 
 fyrox = "0.26.0"
+
+# Fixes window resizing (see https://github.com/rust-windowing/winit/issues/2306).
+#
+[patch.crates-io]
+winit = {git = "https://github.com/rust-windowing/winit.git", rev = "5d85c10a2ccdb5254fc0143247f95cc8e5847c03"}

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -38,15 +38,7 @@ pub struct GameGlobal {
 
 impl GameState for GameGlobal {
     fn init(engine: &mut Engine) -> Self {
-        // It's not possible to disable resizing immediately; the requests will go into a race condition,
-        // and the disable can go first, voiding set_inner_size(); in order to work this around, the
-        // resizing disable is set on on_window_event().
-        // See https://github.com/rust-windowing/winit/issues/2306.
-        //
-        engine.get_window().set_inner_size(PhysicalSize {
-            width: WIDTH,
-            height: HEIGHT,
-        });
+        Self::preset_window(engine);
 
         let mut scene = Scene::new();
 
@@ -87,22 +79,16 @@ impl GameState for GameGlobal {
         self.input.flush_event_received_state();
     }
 
-    fn on_window_event(&mut self, engine: &mut Engine, event: WindowEvent) {
-        match event {
-            WindowEvent::KeyboardInput { input, .. } => {
-                if let Some(key_code) = input.virtual_keycode {
-                    use ElementState::*;
+    fn on_window_event(&mut self, _engine: &mut Engine, event: WindowEvent) {
+        if let WindowEvent::KeyboardInput { input, .. } = event {
+            if let Some(key_code) = input.virtual_keycode {
+                use ElementState::*;
 
-                    match input.state {
-                        Pressed => self.input.key_down(key_code),
-                        Released => self.input.key_up(key_code),
-                    }
+                match input.state {
+                    Pressed => self.input.key_down(key_code),
+                    Released => self.input.key_up(key_code),
                 }
             }
-            WindowEvent::Resized(..) => {
-                engine.get_window().set_resizable(false);
-            }
-            _ => {}
         }
     }
 }
@@ -111,6 +97,20 @@ impl GameState for GameGlobal {
 // the source code simpler.
 //
 impl GameGlobal {
+    fn preset_window(engine: &Engine) {
+        let window = engine.get_window();
+
+        // WATCH OUT! Don't invert this and the following, otherwise, resize won't work.
+        // See https://github.com/rust-windowing/winit/issues/2306.
+        //
+        window.set_resizable(false);
+
+        window.set_inner_size(PhysicalSize {
+            width: WIDTH,
+            height: HEIGHT,
+        });
+    }
+
     fn update(&mut self, engine: &mut Engine) {
         use VirtualKeyCode::*;
         use {MenuState::*, State::*};


### PR DESCRIPTION
Allow window resizing without workaround, thanks to the new winit version.

See https://github.com/rust-windowing/winit/issues/2306.