### PR TITLE
Soccer-fyrox: Implement anchoring, Player/Ball initializers, and other

### DIFF
--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -752,9 +752,9 @@ class Game:
 #         # second on team 1, the third on team 0 etc. The player that kicks off will always be the first player of
 #         # the relevant team.
 #         self.kickoff_player = self.players[other_team]
-
-        # Set pos of kickoff player. A team 0 player will stand to the left of the ball, team 1 on the right
-        self.kickoff_player.vpos = Vector2(HALF_LEVEL_W - 30 + other_team * 60, HALF_LEVEL_H)
+#
+#         # Set pos of kickoff player. A team 0 player will stand to the left of the ball, team 1 on the right
+#         self.kickoff_player.vpos = Vector2(HALF_LEVEL_W - 30 + other_team * 60, HALF_LEVEL_H)
 
         # Create ball
         self.ball = Ball()

--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -443,19 +443,19 @@ class Player(MyActor):
     ANCHOR = (25,37)
 
     def __init__(self, x, y, team):
-        # Player objects are recreated each time there is a kickoff
-        # Team will be 0 or 1
-        # The x and y values supplied represent our 'home' position - the place we'll return to by default when not near
-        # the ball. However, on creation, we want players to be in their kickoff positions, which means all players from
-        # team 0 will be below the halfway line, and players from team 1 above. The player chosen to actually do the
-        # kickoff is moved to be alongside the centre spot after the player objects have been created.
-
-        # Calculate our initial position for kickoff by halving y, adding 550 and then subtracting either 400 for
-        # team 1, or nothing for team 0
-        kickoff_y = (y / 2) + 550 - (team * 400)
-
-        # Call the constructor of the parent class (MyActor)
-        super().__init__("blank", x, kickoff_y, Player.ANCHOR)
+#         # Player objects are recreated each time there is a kickoff
+#         # Team will be 0 or 1
+#         # The x and y values supplied represent our 'home' position - the place we'll return to by default when not near
+#         # the ball. However, on creation, we want players to be in their kickoff positions, which means all players from
+#         # team 0 will be below the halfway line, and players from team 1 above. The player chosen to actually do the
+#         # kickoff is moved to be alongside the centre spot after the player objects have been created.
+#
+#         # Calculate our initial position for kickoff by halving y, adding 550 and then subtracting either 400 for
+#         # team 1, or nothing for team 0
+#         kickoff_y = (y / 2) + 550 - (team * 400)
+#
+#         # Call the constructor of the parent class (MyActor)
+#         super().__init__("blank", x, kickoff_y, Player.ANCHOR)
 
         # Remember home position, where we'll stand by default if we're not active (i.e. far from the ball)
         self.home = Vector2(x, y)

--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -440,7 +440,7 @@ def cost(pos, team, handicap=0):
     return result, pos
 
 class Player(MyActor):
-    ANCHOR = (25,37)
+#     ANCHOR = (25,37)
 
     def __init__(self, x, y, team):
 #         # Player objects are recreated each time there is a kickoff

--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -456,22 +456,22 @@ class Player(MyActor):
 #
 #         # Call the constructor of the parent class (MyActor)
 #         super().__init__("blank", x, kickoff_y, Player.ANCHOR)
-
-        # Remember home position, where we'll stand by default if we're not active (i.e. far from the ball)
-        self.home = Vector2(x, y)
-
-        # Store team
-        self.team = team
-
-        # Facing direction: 0 = up, 1 = top right, up to 7 = top left
-        self.dir = 0
-
-        # Animation frame
-        self.anim_frame = -1
-
-        self.timer = 0
-
-        self.shadow = MyActor("blank", 0, 0, Player.ANCHOR)
+#
+#         # Remember home position, where we'll stand by default if we're not active (i.e. far from the ball)
+#         self.home = Vector2(x, y)
+#
+#         # Store team
+#         self.team = team
+#
+#         # Facing direction: 0 = up, 1 = top right, up to 7 = top left
+#         self.dir = 0
+#
+#         # Animation frame
+#         self.anim_frame = -1
+#
+#         self.timer = 0
+#
+#         self.shadow = MyActor("blank", 0, 0, Player.ANCHOR)
 
         # Used when DEBUG_SHOW_TARGETS is on
         self.debug_target = Vector2(0, 0)

--- a/soccer-fyrox/resources/soccer.py
+++ b/soccer-fyrox/resources/soccer.py
@@ -229,16 +229,16 @@ def on_pitch(x, y):
            or GOAL_1_RECT.collidepoint(x,y)
 
 class Ball(MyActor):
-    def __init__(self):
-        super().__init__("ball", HALF_LEVEL_W, HALF_LEVEL_H)
-
-        # Velocity
-        self.vel = Vector2(0, 0)
-
-        self.owner = None
-        self.timer = 0
-
-        self.shadow = MyActor("balls")
+#     def __init__(self):
+#         super().__init__("ball", HALF_LEVEL_W, HALF_LEVEL_H)
+#
+#         # Velocity
+#         self.vel = Vector2(0, 0)
+#
+#         self.owner = None
+#         self.timer = 0
+#
+#         self.shadow = MyActor("balls")
 
     # Check for collision with player p
     def collide(self, p):

--- a/soccer-fyrox/src/anchor.rs
+++ b/soccer-fyrox/src/anchor.rs
@@ -1,0 +1,7 @@
+use fyrox::core::algebra::Vector2;
+
+#[derive(Clone, Copy)]
+pub enum Anchor {
+    Center,
+    Custom(Vector2<i16>),
+}

--- a/soccer-fyrox/src/ball.rs
+++ b/soccer-fyrox/src/ball.rs
@@ -1,0 +1,33 @@
+use crate::prelude::*;
+
+#[my_actor_based]
+pub struct Ball {
+    vel: Vector2<f32>,
+    pub owner: Option<RCC<Player>>,
+    timer: i32,
+}
+
+impl Ball {
+    pub fn new() -> Self {
+        let vpos = Vector2::new(HALF_LEVEL_W, HALF_LEVEL_H);
+
+        let img_base = "ball";
+        let img_indexes = vec![];
+
+        //# Velocity
+        let vel = Vector2::new(0.0, 0.0);
+
+        let owner = None;
+        let timer: i32 = 0;
+
+        Self {
+            img_base,
+            img_indexes,
+            vpos,
+            vel,
+            owner,
+            timer,
+            anchor: Anchor::Center,
+        }
+    }
+}

--- a/soccer-fyrox/src/ball.rs
+++ b/soccer-fyrox/src/ball.rs
@@ -5,6 +5,7 @@ pub struct Ball {
     vel: Vector2<f32>,
     pub owner: Option<RCC<Player>>,
     timer: i32,
+    shadow: BareActor,
 }
 
 impl Ball {
@@ -18,16 +19,19 @@ impl Ball {
         let vel = Vector2::new(0.0, 0.0);
 
         let owner = None;
-        let timer: i32 = 0;
+        let timer = 0;
+
+        let shadow = BareActor::new(Anchor::Center);
 
         Self {
             img_base,
             img_indexes,
             vpos,
+            anchor: Anchor::Center,
             vel,
             owner,
             timer,
-            anchor: Anchor::Center,
+            shadow,
         }
     }
 }

--- a/soccer-fyrox/src/bare_actor.rs
+++ b/soccer-fyrox/src/bare_actor.rs
@@ -1,0 +1,20 @@
+use crate::prelude::*;
+
+#[my_actor_based]
+pub struct BareActor {}
+
+impl BareActor {
+    pub fn new(anchor: Anchor) -> Self {
+        let vpos = Vector2::new(0, 0);
+
+        let img_base = "blank";
+        let img_indexes = vec![];
+
+        Self {
+            vpos,
+            img_base,
+            img_indexes,
+            anchor,
+        }
+    }
+}

--- a/soccer-fyrox/src/game.rs
+++ b/soccer-fyrox/src/game.rs
@@ -124,6 +124,10 @@ impl Game {
         //# second on team 1, the third on team 0 etc. The player that kicks off will always be the first player of
         //# the relevant team.
         self.kickoff_player = Some(Rc::clone(&self.players[other_team as usize]));
+
+        //# Set pos of kickoff player. A team 0 player will stand to the left of the ball, team 1 on the right
+        self.kickoff_player.as_ref().unwrap().borrow_mut().vpos =
+            Vector2::new(HALF_LEVEL_W - 30 + other_team * 60, HALF_LEVEL_H);
     }
 
     pub fn update(&mut self) {

--- a/soccer-fyrox/src/game_global.rs
+++ b/soccer-fyrox/src/game_global.rs
@@ -190,13 +190,20 @@ impl GameGlobal {
                     Difficulty => (1, self.menu_difficulty),
                 };
 
-                self.media
-                    .draw_image(scene, "menu", &[image_i1, image_i2], 0, 0, 0);
+                self.media.draw_image(
+                    scene,
+                    "menu",
+                    &[image_i1, image_i2],
+                    0,
+                    0,
+                    0,
+                    Anchor::Center,
+                );
             }
             Play => {
                 //# Display score bar at top
                 self.media
-                    .draw_image(scene, "bar", &[], HALF_WINDOW_W - 176, 0, 0);
+                    .draw_image(scene, "bar", &[], HALF_WINDOW_W - 176, 0, 0, Anchor::Center);
                 //# Show score for each team
                 for i in 0..2 {
                     self.media.draw_image(
@@ -206,6 +213,7 @@ impl GameGlobal {
                         HALF_WINDOW_W + 7 - 39 * (i as i16),
                         6,
                         0,
+                        Anchor::Center,
                     );
                 }
 
@@ -218,13 +226,15 @@ impl GameGlobal {
                         HALF_WINDOW_W - 300,
                         HEIGHT / 2 - 88,
                         0,
+                        Anchor::Center,
                     );
                 }
             }
             GameOver => {
                 //# Display "Game Over" image
                 let index = (self.game.teams[1].score > self.game.teams[0].score) as u8;
-                self.media.draw_image(scene, "over", &[index], 0, 0, 0);
+                self.media
+                    .draw_image(scene, "over", &[index], 0, 0, 0, Anchor::Center);
 
                 //# Show score for each team
                 for i in 0..2 {
@@ -235,6 +245,7 @@ impl GameGlobal {
                         HALF_WINDOW_W + 25 - 125 * i,
                         144,
                         0,
+                        Anchor::Center,
                     );
                 }
             }

--- a/soccer-fyrox/src/goal.rs
+++ b/soccer-fyrox/src/goal.rs
@@ -19,6 +19,7 @@ impl Goal {
             img_indexes,
             vpos,
             team,
+            anchor: Anchor::Center,
         }
     }
 }

--- a/soccer-fyrox/src/main.rs
+++ b/soccer-fyrox/src/main.rs
@@ -2,6 +2,7 @@
 // #![allow(unused_variables)]
 #![allow(dead_code)]
 
+mod anchor;
 mod controls;
 mod difficulty;
 mod game;
@@ -26,6 +27,7 @@ pub mod prelude {
         scene::{base::BaseBuilder, node::Node, transform::TransformBuilder, Scene},
     };
 
+    pub use crate::anchor::Anchor;
     pub use crate::controls::Controls;
     pub use crate::difficulty::{Difficulty, DIFFICULTY};
     pub use crate::game::{Game, DEFAULT_DIFFICULTY};

--- a/soccer-fyrox/src/main.rs
+++ b/soccer-fyrox/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 mod anchor;
+mod bare_actor;
 mod controls;
 mod difficulty;
 mod game;
@@ -28,6 +29,7 @@ pub mod prelude {
     };
 
     pub use crate::anchor::Anchor;
+    pub use crate::bare_actor::BareActor;
     pub use crate::controls::Controls;
     pub use crate::difficulty::{Difficulty, DIFFICULTY};
     pub use crate::game::{Game, DEFAULT_DIFFICULTY};

--- a/soccer-fyrox/src/main.rs
+++ b/soccer-fyrox/src/main.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 mod anchor;
+mod ball;
 mod bare_actor;
 mod controls;
 mod difficulty;
@@ -29,6 +30,7 @@ pub mod prelude {
     };
 
     pub use crate::anchor::Anchor;
+    pub use crate::ball::Ball;
     pub use crate::bare_actor::BareActor;
     pub use crate::controls::Controls;
     pub use crate::difficulty::{Difficulty, DIFFICULTY};

--- a/soccer-fyrox/src/media.rs
+++ b/soccer-fyrox/src/media.rs
@@ -142,6 +142,7 @@ impl Media {
         std_x: i16,
         std_y: i16,
         z: i16,
+        anchor: Anchor,
     ) {
         let texture = self.image(base, indexes);
         let texture_kind = texture.data_ref().kind();
@@ -151,8 +152,18 @@ impl Media {
             height: texture_height,
         } = texture_kind
         {
-            let fyrox_x = WIDTH as f32 / 2.0 - texture_width as f32 / 2.0 - std_x as f32;
-            let fyrox_y = HEIGHT as f32 / 2.0 - texture_height as f32 / 2.0 - std_y as f32;
+            let mut fyrox_x = WIDTH as f32 / 2.0 - texture_width as f32 / 2.0 - std_x as f32;
+            let mut fyrox_y = HEIGHT as f32 / 2.0 - texture_height as f32 / 2.0 - std_y as f32;
+
+            use Anchor::*;
+
+            match anchor {
+                Center => {}
+                Custom(anchor) => {
+                    fyrox_x += texture_width as f32 / 2.0 - anchor.x as f32;
+                    fyrox_y += texture_height as f32 / 2.0 - anchor.y as f32;
+                }
+            };
 
             let node = RectangleBuilder::new(
                 BaseBuilder::new().with_local_transform(

--- a/soccer-fyrox/src/my_actor.rs
+++ b/soccer-fyrox/src/my_actor.rs
@@ -1,6 +1,6 @@
 use fyrox::{core::algebra::Vector2, scene::Scene};
 
-use crate::media::Media;
+use crate::{anchor::Anchor, media::Media};
 
 //# The MyActor class extends Pygame Zero's Actor class by providing the attribute 'vpos', which stores the object's
 //# current position using Pygame's Vector2 class. All code should change or read the position via vpos, as opposed to
@@ -10,6 +10,7 @@ pub trait MyActor {
     fn vpos(&self) -> Vector2<i16>;
     fn img_base(&self) -> &'static str;
     fn img_indexes(&self) -> &[u8];
+    fn anchor(&self) -> Anchor;
 
     //# We draw with the supplied offset to enable scrolling
     fn draw(&self, scene: &mut Scene, media: &mut Media, offset_x: i16, offset_y: i16) {

--- a/soccer-fyrox/src/my_actor.rs
+++ b/soccer-fyrox/src/my_actor.rs
@@ -17,6 +17,14 @@ pub trait MyActor {
         let pos_x = self.vpos().x - offset_x;
         let pos_y = self.vpos().y - offset_y;
 
-        media.draw_image(scene, self.img_base(), &self.img_indexes(), pos_x, pos_y, 0);
+        media.draw_image(
+            scene,
+            self.img_base(),
+            &self.img_indexes(),
+            pos_x,
+            pos_y,
+            0,
+            self.anchor(),
+        );
     }
 }

--- a/soccer-fyrox/src/player.rs
+++ b/soccer-fyrox/src/player.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 
+#[my_actor_based]
 pub struct Player {
     // We trivially solve the cyclical references problem, by erasing the references at the start of
     // each game.
@@ -7,9 +8,29 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(_x: i16, _y: i16, _team: u8) -> Self {
+    pub fn new(x: i16, y: i16, team: u8) -> Self {
+        //# Player objects are recreated each time there is a kickoff
+        //# Team will be 0 or 1
+        //# The x and y values supplied represent our 'home' position - the place we'll return to by default when not near
+        //# the ball. However, on creation, we want players to be in their kickoff positions, which means all players from
+        //# team 0 will be below the halfway line, and players from team 1 above. The player chosen to actually do the
+        //# kickoff is moved to be alongside the centre spot after the player objects have been created.
+
+        //# Calculate our initial position for kickoff by halving y, adding 550 and then subtracting either 400 for
+        //# team 1, or nothing for team 0
+        let kickoff_y = (y / 2) + 550 - (team as i16 * 400);
+
+        let vpos = Vector2::new(x, kickoff_y);
+        let img_base = "blank";
+        let img_indexes = vec![];
+
         let peer = None;
 
-        Self { peer }
+        Self {
+            vpos,
+            img_base,
+            img_indexes,
+            peer,
+        }
     }
 }

--- a/soccer-fyrox/src/player.rs
+++ b/soccer-fyrox/src/player.rs
@@ -7,6 +7,11 @@ pub struct Player {
     // We trivially solve the cyclical references problem, by erasing the references at the start of
     // each game.
     pub peer: Option<RCC<Player>>,
+    home: Vector2<i16>,
+    dir: u8,
+    anim_frame: i8,
+    timer: i32,
+    shadow: BareActor,
 }
 
 impl Player {
@@ -28,12 +33,30 @@ impl Player {
 
         let peer = None;
 
+        //# Remember home position, where we'll stand by default if we're not active (i.e. far from the ball)
+        let home = Vector2::new(x, y);
+
+        //# Facing direction: 0 = up, 1 = top right, up to 7 = top left
+        let dir = 0;
+
+        //# Animation frame
+        let anim_frame = -1;
+
+        let timer = 0;
+
+        let shadow = BareActor::new(Anchor::Custom(ANCHOR));
+
         Self {
             vpos,
             img_base,
             img_indexes,
             anchor: Anchor::Custom(ANCHOR),
             peer,
+            home,
+            dir,
+            anim_frame,
+            timer,
+            shadow,
         }
     }
 }

--- a/soccer-fyrox/src/player.rs
+++ b/soccer-fyrox/src/player.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+const ANCHOR: Vector2<i16> = Vector2::new(25, 37);
+
 #[my_actor_based]
 pub struct Player {
     // We trivially solve the cyclical references problem, by erasing the references at the start of
@@ -30,6 +32,7 @@ impl Player {
             vpos,
             img_base,
             img_indexes,
+            anchor: Anchor::Custom(ANCHOR),
             peer,
         }
     }

--- a/soccer-macros-fyrox/src/lib.rs
+++ b/soccer-macros-fyrox/src/lib.rs
@@ -22,6 +22,7 @@ pub fn my_actor_based(args: TokenStream, input: TokenStream) -> TokenStream {
             quote! { img_base: &'static str },
             quote! { img_indexes: Vec<u8> },
             quote! { pub vpos: Vector2<i16> },
+            quote! { anchor: Anchor },
         ];
 
         for field_tokens in fields_tokens {
@@ -49,6 +50,10 @@ pub fn my_actor_based(args: TokenStream, input: TokenStream) -> TokenStream {
 
             fn img_indexes(&self) -> &[u8] {
                 &self.img_indexes
+            }
+
+            fn anchor(&self) -> Anchor {
+                self.anchor
             }
         }
     };


### PR DESCRIPTION
Mostly, logic supporting the Player and ball initializer; most importantly, anchoring. Other things include:

- a "BareActor" type
- progress with Game#reset
- derive my_actor_based for Player