### PR TITLE
Rusty Roguelike: Fix state management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The ECS part of this game, originally Legion, has been ported to Bevy (the graph
 
 I wrote a mini book, ["Learn Bevy's ECS by ripping off someone else's project"](https://saveriomiroddi.github.io/learn_bevy_ecs_by_ripping_off), based on this project.
 
+Please note that in all steps except the last (15.02), the FOV flickers. The fix (see [fix commit](/../../commit/71655f2d7e)) can be easily backported to the previous steps; if anybody wants to contribute the backport, they're very welcome 😄.
+
 ### Soccer/Fyrox
 
 ![Soccer](/images/readme/soccer.png?raw=true)

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/main.rs
@@ -54,7 +54,7 @@ impl State {
             .add_stage_after(MovePlayer, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterCollisions, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/mod.rs
@@ -43,12 +43,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(entity_render::entity_render),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(collisions::collisions)
             .with_system(end_turn::end_turn)
             .into(),
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .into(),
     );
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCollisions,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(collisions::collisions)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_02_turnbased/src/systems/player_input.rs
@@ -26,7 +26,7 @@ pub fn player_input(
                 }
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/main.rs
@@ -59,7 +59,7 @@ impl State {
             .add_stage_after(Collisions, GenerateMonsterMoves, SystemStage::parallel())
             .add_stage_after(GenerateMonsterMoves, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/mod.rs
@@ -44,12 +44,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(entity_render::entity_render),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .into(),
     );
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         Collisions,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(collisions::collisions)
             .with_system(end_turn::end_turn)
             .into(),
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .into(),
     );
@@ -74,7 +74,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/07_TurnBasedGames_03_intent/src/systems/player_input.rs
@@ -27,7 +27,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/main.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/main.rs
@@ -59,7 +59,7 @@ impl State {
             .add_stage_after(Collisions, GenerateMonsterMoves, SystemStage::parallel())
             .add_stage_after(GenerateMonsterMoves, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/mod.rs
@@ -50,12 +50,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(tooltips::tooltips),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .into(),
     );
@@ -63,7 +63,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         Collisions,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(collisions::collisions)
             .with_system(end_turn::end_turn)
             .into(),
@@ -72,7 +72,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .into(),
     );
@@ -80,7 +80,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_01_health/src/systems/player_input.rs
@@ -27,7 +27,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/main.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/main.rs
@@ -61,7 +61,7 @@ impl State {
             .add_stage_after(GenerateMonsterMoves, MonsterCombat, SystemStage::parallel())
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/mod.rs
@@ -50,12 +50,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(tooltips::tooltips),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -63,7 +63,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -72,7 +72,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .into(),
     );
@@ -80,7 +80,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -88,7 +88,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_02_combat/src/systems/player_input.rs
@@ -46,7 +46,7 @@ pub fn player_input(
             }
         }
 
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/main.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/main.rs
@@ -61,7 +61,7 @@ impl State {
             .add_stage_after(GenerateMonsterMoves, MonsterCombat, SystemStage::parallel())
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/mod.rs
@@ -50,12 +50,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(tooltips::tooltips),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -63,7 +63,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -72,7 +72,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .into(),
     );
@@ -80,7 +80,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -88,7 +88,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/08_HealthSimpleMelee_03_healing/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/main.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/main.rs
@@ -61,7 +61,7 @@ impl State {
             .add_stage_after(GenerateMonsterMoves, MonsterCombat, SystemStage::parallel())
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);

--- a/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/end_turn.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
-pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>) {
-    let new_state = match turn_state.0 {
+pub fn end_turn(mut commands: Commands, turn_state: Res<TurnState>) {
+    let new_state = match *turn_state {
         // In the source project, AwaitingInput returns AwaitingInput, however, it's actually an unreachable
         // case, because the change to the next state (PlayerTurn) is performed in the `player_input` system.
         TurnState::AwaitingInput => unreachable!(),
@@ -9,5 +9,5 @@ pub fn end_turn(mut commands: Commands, turn_state: Res<CurrentState<TurnState>>
         TurnState::MonsterTurn => TurnState::AwaitingInput,
     };
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/mod.rs
@@ -51,12 +51,12 @@ pub fn build_system_sets(app: &mut App) {
             .with_system(tooltips::tooltips),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -64,7 +64,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_01_gauntlet/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/main.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/main.rs
@@ -61,7 +61,7 @@ impl State {
             .add_stage_after(GenerateMonsterMoves, MonsterCombat, SystemStage::parallel())
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -115,7 +115,7 @@ impl State {
             self.ecs
                 .insert_resource(Camera::new(map_builder.player_start));
             self.ecs
-                .insert_resource(NextState(TurnState::AwaitingInput));
+                .insert_resource(TurnState::AwaitingInput);
             // Don't forget! :)
             self.ecs.world.remove_resource::<VirtualKeyCode>();
         }
@@ -142,8 +142,8 @@ impl GameState for State {
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
         if matches!(
-            self.ecs.world.get_resource::<CurrentState<TurnState>>(),
-            Some(CurrentState(TurnState::GameOver))
+            self.ecs.world.get_resource::<TurnState>(),
+            Some(TurnState::GameOver)
         ) {
             self.game_over(ctx);
         }

--- a/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/end_turn.rs
@@ -3,9 +3,9 @@ use crate::prelude::*;
 pub fn end_turn(
     mut commands: Commands,
     player_query: Query<&Health, With<Player>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -18,5 +18,5 @@ pub fn end_turn(
         new_state = TurnState::GameOver;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/mod.rs
@@ -43,7 +43,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -53,12 +53,12 @@ pub fn build_system_sets(app: &mut App) {
             .into(),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_02_losing/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/main.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(GenerateMonsterMoves, MonsterCombat, SystemStage::parallel())
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -92,7 +92,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
     }
@@ -175,9 +175,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/mod.rs
@@ -43,7 +43,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -53,12 +53,12 @@ pub fn build_system_sets(app: &mut App) {
             .into(),
     );
 
-    app.add_system(player_input::player_input.run_in_state(AwaitingInput));
+    app.add_system(player_input::player_input.run_if_resource_equals(AwaitingInput));
 
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),

--- a/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/09_WinningAndLosing_03_winning/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/main.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/main.rs
@@ -64,7 +64,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -94,7 +94,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
     }
@@ -177,9 +177,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_01_fov/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/main.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/main.rs
@@ -64,7 +64,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -94,7 +94,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
     }
@@ -177,9 +177,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_02_eyesight/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/main.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/main.rs
@@ -64,7 +64,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -94,7 +94,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
     }
@@ -177,9 +177,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/10_WhatCanISee_03_memory/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/main.rs
+++ b/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
         build_system_sets(&mut ecs);
@@ -90,7 +90,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
     }
@@ -173,9 +173,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/11_MoreInterestingDungeons/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/12_MapTheming/src/main.rs
+++ b/rusty_roguelike-bevy/12_MapTheming/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -91,7 +91,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -175,9 +175,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/12_MapTheming/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/12_MapTheming/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/12_MapTheming/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/12_MapTheming/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/12_MapTheming/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/12_MapTheming/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/main.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -91,7 +91,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -175,9 +175,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/mod.rs
@@ -44,7 +44,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -56,7 +56,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -65,7 +65,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -73,7 +73,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -82,7 +82,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -90,7 +90,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -99,7 +99,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(combat::combat)
             .into(),
     );
@@ -107,7 +107,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -116,7 +116,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_01_potions_and_scrolls/src/systems/player_input.rs
@@ -54,7 +54,7 @@ pub fn player_input(
             // Using Bevy's query system, this logic is considerably simpler.
             player_health.current = i32::min(player_health.max, player_health.current + 1);
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/main.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/main.rs
@@ -63,7 +63,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -92,7 +92,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -176,9 +176,9 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/end_turn.rs
@@ -4,10 +4,10 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -25,5 +25,5 @@ pub fn end_turn(
         new_state = TurnState::Victory;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/mod.rs
@@ -45,7 +45,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -101,7 +101,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -110,7 +110,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -119,7 +119,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/13_InventoryAndPowerUps_02_carrying_items/src/systems/player_input.rs
@@ -82,7 +82,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/14_DeeperDungeons/src/main.rs
+++ b/rusty_roguelike-bevy/14_DeeperDungeons/src/main.rs
@@ -65,7 +65,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -96,7 +96,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -159,7 +159,7 @@ impl State {
             .world
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.world.insert_resource(map_builder.theme);
     }
 
@@ -241,10 +241,10 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
-            Some(CurrentState(TurnState::NextLevel)) => self.advance_level(),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
+            Some(TurnState::NextLevel) => self.advance_level(),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/end_turn.rs
@@ -4,11 +4,11 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
     map: Res<Map>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -31,5 +31,5 @@ pub fn end_turn(
         new_state = TurnState::NextLevel;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/mod.rs
@@ -45,7 +45,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -101,7 +101,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -110,7 +110,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -119,7 +119,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/14_DeeperDungeons/src/systems/player_input.rs
@@ -82,7 +82,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/main.rs
+++ b/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -94,7 +94,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -159,7 +159,7 @@ impl State {
             .world
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.world.insert_resource(map_builder.theme);
     }
 
@@ -241,10 +241,10 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
-            Some(CurrentState(TurnState::NextLevel)) => self.advance_level(),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
+            Some(TurnState::NextLevel) => self.advance_level(),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/end_turn.rs
@@ -4,11 +4,11 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
     map: Res<Map>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -31,5 +31,5 @@ pub fn end_turn(
         new_state = TurnState::NextLevel;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/mod.rs
@@ -45,7 +45,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -101,7 +101,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -110,7 +110,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -119,7 +119,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/15_Loot_01_loot_tables/src/systems/player_input.rs
@@ -82,7 +82,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/main.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/main.rs
@@ -5,6 +5,7 @@ mod game_stage;
 mod map;
 mod map_builder;
 mod spawner;
+mod state_label;
 mod systems;
 mod turn_state;
 
@@ -24,6 +25,7 @@ mod prelude {
     pub use crate::map::*;
     pub use crate::map_builder::*;
     pub use crate::spawner::*;
+    pub use crate::state_label::*;
     pub use crate::systems::*;
     pub use crate::turn_state::*;
 }

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/main.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/main.rs
@@ -62,7 +62,7 @@ impl State {
             .add_stage_after(MonsterCombat, MoveMonsters, SystemStage::parallel())
             .add_stage_after(MoveMonsters, MonsterFov, SystemStage::parallel());
         // Set the startup state.
-        ecs.add_loopless_state(TurnState::AwaitingInput);
+        ecs.insert_resource(TurnState::AwaitingInput);
         ecs.insert_resource(map_builder.theme);
         // In the source project, set of actions (`Schedule`s) are owned by State (`systems: Schedule`);
         // here, they're owned by the Bevy ECS, as `SystemSet`s.
@@ -94,7 +94,7 @@ impl State {
         self.ecs
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.insert_resource(map_builder.theme);
         // Don't forget! :)
         self.ecs.world.remove_resource::<VirtualKeyCode>();
@@ -159,7 +159,7 @@ impl State {
             .world
             .insert_resource(Camera::new(map_builder.player_start));
         self.ecs
-            .insert_resource(NextState(TurnState::AwaitingInput));
+            .insert_resource(TurnState::AwaitingInput);
         self.ecs.world.insert_resource(map_builder.theme);
     }
 
@@ -241,10 +241,10 @@ impl GameState for State {
         self.ecs.insert_resource(Point::from_tuple(ctx.mouse_pos()));
         // Unfortunately, with the current source project's design, without refactoring the world init
         // code into systems, we must leak the state into this abstraction.
-        match self.ecs.world.get_resource::<CurrentState<TurnState>>() {
-            Some(CurrentState(TurnState::GameOver)) => self.game_over(ctx),
-            Some(CurrentState(TurnState::Victory)) => self.victory(ctx),
-            Some(CurrentState(TurnState::NextLevel)) => self.advance_level(),
+        match self.ecs.world.get_resource::<TurnState>() {
+            Some(TurnState::GameOver) => self.game_over(ctx),
+            Some(TurnState::Victory) => self.victory(ctx),
+            Some(TurnState::NextLevel) => self.advance_level(),
             _ => {}
         }
         self.ecs.update();

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/state_label.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/state_label.rs
@@ -1,0 +1,8 @@
+use crate::prelude::*;
+
+// Only Fov is currently required; a String works as well, but this is the clean approach.
+//
+#[derive(Debug, Clone, PartialEq, Eq, Hash, SystemLabel)]
+pub enum StateLabel {
+    Fov,
+}

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/end_turn.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/end_turn.rs
@@ -4,11 +4,11 @@ pub fn end_turn(
     mut commands: Commands,
     player_query: Query<(&Health, &PointC), With<Player>>,
     amulet_query: Query<&PointC, With<AmuletOfYala>>,
-    turn_state: Res<CurrentState<TurnState>>,
+    turn_state: Res<TurnState>,
     map: Res<Map>,
 ) {
     let (player_hp, player_pos) = player_query.single();
-    let mut new_state = match turn_state.0 {
+    let mut new_state = match *turn_state {
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
         // In the source project, AwaitingInput and GameOver return (themselves), however, they're actually
@@ -31,5 +31,5 @@ pub fn end_turn(
         new_state = TurnState::NextLevel;
     }
 
-    commands.insert_resource(NextState(new_state));
+    commands.insert_resource(new_state);
 }

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/mod.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/mod.rs
@@ -45,7 +45,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_not_in_state(GameOver)
+            .run_unless_resource_equals(GameOver)
             .with_system(map_render::map_render)
             .with_system(entity_render::entity_render)
             .with_system(hud::hud)
@@ -57,7 +57,7 @@ pub fn build_system_sets(app: &mut App) {
 
     app.add_system_set(
         ConditionSet::new()
-            .run_in_state(AwaitingInput)
+            .run_if_resource_equals(AwaitingInput)
             .with_system(player_input::player_input)
             .with_system(fov::fov)
             .into(),
@@ -66,7 +66,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerCombat,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -75,7 +75,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MovePlayer,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -84,7 +84,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         PlayerFov,
         ConditionSet::new()
-            .run_in_state(PlayerTurn)
+            .run_if_resource_equals(PlayerTurn)
             .with_system(fov::fov)
             .into(),
     );
@@ -92,7 +92,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         GenerateMonsterMoves,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(random_move::random_move)
             .with_system(chasing::chasing)
             .into(),
@@ -101,7 +101,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterCombat,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(use_items::use_items)
             .with_system(combat::combat)
             .into(),
@@ -110,7 +110,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MoveMonsters,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(movement::movement)
             .with_system(end_turn::end_turn)
             .into(),
@@ -119,7 +119,7 @@ pub fn build_system_sets(app: &mut App) {
     app.add_system_set_to_stage(
         MonsterFov,
         ConditionSet::new()
-            .run_in_state(MonsterTurn)
+            .run_if_resource_equals(MonsterTurn)
             .with_system(fov::fov)
             .into(),
     );

--- a/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/player_input.rs
+++ b/rusty_roguelike-bevy/15_Loot_02_better_combat/src/systems/player_input.rs
@@ -92,7 +92,7 @@ pub fn player_input(
                 });
             }
         }
-        commands.insert_resource(NextState(TurnState::PlayerTurn));
+        commands.insert_resource(TurnState::PlayerTurn);
 
         // WATCH OUT!! If they key resource is not removed, multiple keypresses will be detected over
         // the same frame. This is because a system (set) may run multiple times over a frame, due to


### PR DESCRIPTION
Fix the state management, by using resources.

Note that the FOV blinks; this has been fixed only on 15.02, due to the (minor) tediousness of the search/replace.