### PR TITLE
Boing: Canonicalize resource paths, for Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ I currently don't plan any further ports.
 
 ## Notes
 
-Nightly Rust may be required for some games.
+Nightly Rust may be required for some games. The games have been developed tested on Linux; if anybody finds issues with Windows, open an issue and I'll quickly look into it 😄
 
 The games have been carefully ported; some design details have been implemented non-idiomatically; this has been intentional, in order not to diverge too much from the original projects (and therefore, to make direct comparison not too hard). Nonetheless, if you have doubts/suggestions about the quality of the code, you're invited to open an issue 😄
 

--- a/boing-ggez/src/main.rs
+++ b/boing-ggez/src/main.rs
@@ -41,7 +41,7 @@ fn get_resource_dirs() -> Vec<PathBuf> {
 
     RESOURCE_SUBDIRS
         .iter()
-        .map(|subdir| resources_root_dir.join(subdir))
+        .map(|subdir| resources_root_dir.join(subdir).canonicalize().unwrap())
         .collect()
 }
 


### PR DESCRIPTION
Windows doesn't support symlinks (this way), so we need to canonicalize.