### PR TITLE
CI: Include only projects changed by the current PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,18 @@ jobs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v31
+      with:
+        # Newlines are better, but are currently unsupported (https://github.com/tj-actions/changed-files#known-limitation);
+        # commas are equally safe for this project, though.
+        separator: ","
+        dir_names: true
     - id: generate-matrix
-      run: echo ::set-output name=matrix::$(.github/workflows/generate-projects-matrix.sh ${{ github.workspace }})
+      run: echo ::set-output name=matrix::$(.github/workflows/generate-projects-matrix.sh ${{ steps.changed-files.outputs.all_changed_files }})
   check_code_formatting:
     runs-on: ubuntu-latest
     name: Check code formatting
@@ -23,6 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{ fromJson(needs.generate_projects_matrix.outputs.matrix) }}
+    if: ${{ needs.generate_projects_matrix.outputs.matrix != '[]' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/cargo@v1
@@ -37,6 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg: ${{fromJson(needs.generate_projects_matrix.outputs.matrix)}}
+    if: ${{ needs.generate_projects_matrix.outputs.matrix != '[]' }}
     steps:
       - name: Install dev libraries
         run: sudo apt install libasound2-dev libudev-dev

--- a/.github/workflows/generate-projects-matrix.sh
+++ b/.github/workflows/generate-projects-matrix.sh
@@ -7,22 +7,35 @@ set -o errtrace
 shopt -s inherit_errexit
 
 function main {
-  local project_dir=$1
+  local changed_dirs=$1
 
-  # Keep this simple:
-  #
-  # - jq is cool, and it's also unredable 😂;
-  # - we (can) assume that we don't need quoting;
-  # - exclude subprojects, e.g. macro crates;
+  # - we assume that we don't need quoting;
+  # - we include only the root directories, if they include a `Cargo.toml` file;
   # - the JSON is actually JSON5, since a trailing comma is present inside the array; screw JSON.
 
-  echo "["
-  find "$project_dir" -maxdepth 2 -name 'Cargo.toml' -printf '  { "port_manifest": "%P\0" },\n'
-  echo "]"
+  # We don't print newlines in order to simplify testing for empty matrices; the alternative is to
+  # use conditionals, which are a bit ugly.
+  #
+  echo -n "["
+
+  mapfile -td, changed_dirs <<< "$changed_dirs"
+
+  for changed_dir in "${changed_dirs[@]}"; do
+    if [[ $changed_dir != . && $(dirname "$changed_dir") == . ]]; then
+      local cargo_file=$changed_dir/Cargo.toml
+
+      if [[ -f $cargo_file ]]; then
+        echo "  { \"port_manifest\": \"$cargo_file\" },"
+      fi
+    fi
+  done
+
+  echo -n "]"
 }
 
-# Prints a JSON5 document with an array of `{ "port_manifest": "<relative port dir>/Cargo.toml" }`.
+# Filters in the project directories, and prints a JSON5 document with an array of
+# `{ "port_manifest": "<relative_port_dir>/Cargo.toml" }` entries.
 #
-# $1: project (workspace) directory
+# $1: list of changed dirs, separated by comma (limitation of the `changed-files` action).
 #
 main "$@"


### PR DESCRIPTION
Build times are (going to be) problematic. We address this by including in the CI only the projects that have been modified by the current PR.

Closes #146.